### PR TITLE
Set solr cores from .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,5 @@
 # Blank, default to Docker Hub
 REGISTRY_HOST=
 REGISTRY_URI=yalelibraryit/dc-solr
+SOLR_TEST_CORE=blacklight-test
+SOLR_CORE=blacklight-development

--- a/README.md
+++ b/README.md
@@ -45,8 +45,6 @@ Solr for Digital Collections
 
  Use the following fragment in the docker-compose.yml for the application.
 
- Note, this will create two solr cores called `blacklight-test` and `blacklight-development`
-
  ```
  services:
   solr:
@@ -55,8 +53,16 @@ Solr for Digital Collections
       - '8983:8983'
     volumes:
       - solr:/opt/solr/server/solr/mycores
-    command: bash -c 'precreate-core blacklight-development /opt/config; precreate-core blacklight-test /opt/config; exec solr -f'
+    command: bash -c 'precreate-core ${SOLR_CORE} /opt/config; precreate-core ${SOLR_TEST_CORE} /opt/config; exec solr -f'
 
 volumes:
   solr:
  ```
+
+Note, two environment variables are required. Add these to the `.env` file.
+
+``` 
+SOLR_TEST_CORE=blacklight-test
+SOLR_CORE=blacklight-development
+```
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - .env
     build:
       context: .
-    command: bash -c 'precreate-core blacklight-development /opt/config; precreate-core blacklight-test /opt/config; exec solr -f'
+    command: bash -c 'precreate-core ${SOLR_CORE} /opt/config; precreate-core ${SOLR_TEST_CORE} /opt/config; exec solr -f'
 
 volumes:
   solr:


### PR DESCRIPTION
This PR:

* switches out the status solr core names for environment variables in the .env file
* add info on the environment variables to the README