### PR TITLE
Add dynamic field for use with OCR test

### DIFF
--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -25,7 +25,7 @@
     <dynamicField name="*_tsm" type="text" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_tsi" type="text" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_tsim" type="text" stored="true" indexed="true" multiValued="true"/>
-    <dynamicField name="*_wstsim" type="text_ws" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_wstsim" type="text_ocr" stored="true" indexed="true" multiValued="true"/>
 
     <dynamicField name="*_tiv" type="text" stored="false" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>
@@ -279,6 +279,19 @@
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory"/>  <!-- NFKC, case folding, diacritics removed -->
         <filter class="solr.TrimFilterFactory"/>
+      </analyzer>
+    </fieldType>
+
+    <!-- A text field that only splits on wordbreaks and removes punctuation but maintains case -->
+    <fieldType name="text_ocr" class="solr.TextField">
+      <analyzer type="index">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
+        <filter class="solr.FlattenGraphFilterFactory"/>
+      </analyzer>
+      <analyzer type="query">
+        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
+        <filter class="solr.WordDelimiterGraphFilterFactory"/>
       </analyzer>
     </fieldType>
 

--- a/solr/conf/schema.xml
+++ b/solr/conf/schema.xml
@@ -25,6 +25,7 @@
     <dynamicField name="*_tsm" type="text" stored="true" indexed="false" multiValued="true"/>
     <dynamicField name="*_tsi" type="text" stored="true" indexed="true" multiValued="false"/>
     <dynamicField name="*_tsim" type="text" stored="true" indexed="true" multiValued="true"/>
+    <dynamicField name="*_wstsim" type="text_ws" stored="true" indexed="true" multiValued="true"/>
 
     <dynamicField name="*_tiv" type="text" stored="false" indexed="true" multiValued="false" termVectors="true" termPositions="true" termOffsets="true"/>
     <dynamicField name="*_timv" type="text" stored="false" indexed="true" multiValued="true" termVectors="true" termPositions="true" termOffsets="true"/>


### PR DESCRIPTION
This adds a new dynamic field *_wstsim that uses a new field called text_ocr.
This field type will maintain case, but split on word breaks and remove punctuation.  It is used for IIIF suggestions using facets.