### PR TITLE
Remove entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,3 @@ USER root
 COPY solr/conf /opt/config    
 COPY ops/boot.sh /boot.sh    
 USER solr    
-ENTRYPOINT ["/boot.sh"]    


### PR DESCRIPTION
The Dockerfile's entrypoint is overriding `command` from the Camerata docker-compose file, which is needed to precreate cores in the development environment. 