### PR TITLE
Lowers memory allocation

### DIFF
--- a/ops/boot.sh
+++ b/ops/boot.sh
@@ -4,6 +4,6 @@ if [ ! -z "${SOLR_CORE}" ];then
   touch /var/solr/data/${SOLR_CORE}/core.properties
   chown -R solr: /var/solr/data
 fi
-export SOLR_HEAP="${SOLR_HEAP:=62g}"
+export SOLR_HEAP="${SOLR_HEAP:=8g}"
 export SOLR_OPTS="-Dlog4j2.formatMsgNoLookups=true"
 ulimit -n 65000 && docker-entrypoint.sh solr-foreground


### PR DESCRIPTION
# Summary
Per advisement of dev ops, heap should not exceed 32g.  This PR lowers the memory allocation to 8g to match the EC2 set up for the staging environments but will not take effect in production.

# Related Ticket
[#3090](https://github.com/yalelibrary/YUL-DC/issues/3090)